### PR TITLE
adjust line number when scalar block style is used

### DIFF
--- a/yoml-parser.h
+++ b/yoml-parser.h
@@ -55,6 +55,16 @@ static inline yoml_t *yoml__new_node(const char *filename, yoml_type_t type, siz
     node->filename = filename != NULL ? strdup(filename) : NULL;
     node->type = type;
     node->line = event->start_mark.line;
+    if (type == YOML_TYPE_SCALAR) {
+        switch (event->data.scalar.style) {
+        case YAML_LITERAL_SCALAR_STYLE:
+        case YAML_FOLDED_SCALAR_STYLE:
+            ++node->line;
+            break;
+        default:
+            break;
+        }
+    }
     node->column = event->start_mark.column;
     node->anchor = anchor != NULL ? yoml__strdup(anchor) : NULL;
     node->tag = tag != NULL ? yoml__strdup(tag) : NULL;


### PR DESCRIPTION
when [Block Scalar Style](http://yaml.org/spec/1.2/spec.html#id2793652) is used, `yaml_event_t`'s `start_mark.line` indicates the block indicator (i.e. `|` or `>`), but the content always starts from the next line of it.

This causes lineno mismatches in cases like the following:

```
hosts:
  "*":
    paths:
      "/":
        mruby-handler: |
          proc {|env|
            raise "HOGE" # <- line 7
          }
```
but error message says lineno is 6. From yoml users, currently there're no ways to know the scalar style and how to adjust it