### PR TITLE
add resolve_[alias|merge] options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test:
-	$(CC) -Wall -g -I deps/picotest deps/picotest/picotest.c test-yoml.c -lyaml -o test-yoml
+	$(CC) -g -Wall $(COPTS) -I deps/picotest deps/picotest/picotest.c test-yoml.c -lyaml -o test-yoml
 	./test-yoml

--- a/yoml-parser.h
+++ b/yoml-parser.h
@@ -219,7 +219,6 @@ static inline int yoml__merge(yoml_t **dest, size_t offset, yoml_t *src, yoml_pa
     }
 
     /* replace `*dest` with `new_node` */
-    yoml_free(*dest, parse_args->mem_set);
     *dest = new_node;
 
     return 0;
@@ -270,9 +269,6 @@ static inline int yoml__resolve_merge(yoml_t **target, yaml_parser_t *parser, yo
                     memmove((*target)->data.mapping.elements + i, (*target)->data.mapping.elements + i + 1,
                             ((*target)->data.mapping.size - i - 1) * sizeof((*target)->data.mapping.elements[0]));
                     --(*target)->data.mapping.size;
-                    /* cleanup */
-                    yoml_free(src.key, parse_args->mem_set);
-                    yoml_free(src.value, parse_args->mem_set);
                 }
             } while (i != 0);
         }

--- a/yoml-parser.h
+++ b/yoml-parser.h
@@ -187,10 +187,11 @@ static inline int yoml__merge(yoml_t **dest, size_t offset, yoml_t *src, yoml_pa
         return -1;
 
     /* create new node, copy attributes and elements of `*dest` up to `offset` */
-    yoml_t *new_node = malloc(offsetof(yoml_t, data.mapping.elements) + ((*dest)->data.mapping.size + src->data.mapping.size - 1) *
+    yoml_t *new_node = malloc(offsetof(yoml_t, data.mapping.elements) + ((*dest)->data.mapping.size + src->data.mapping.size) *
                                                                             sizeof(new_node->data.mapping.elements[0]));
-    memcpy(new_node, *dest, offsetof(yoml_t, data.mapping.elements) + (offset - 1) * sizeof((*dest)->data.mapping.elements[0]));
-    new_node->data.mapping.size = offset - 1;
+    memcpy(new_node, *dest, offsetof(yoml_t, data.mapping.elements) + offset * sizeof((*dest)->data.mapping.elements[0]));
+    new_node->_refcnt = 1;
+    new_node->data.mapping.size = offset;
 
     /* copy elements from `src`, ignoring the ones that are defined later in `*dest` */
     for (size_t i = 0; i != src->data.mapping.size; ++i) {


### PR DESCRIPTION
What I just wanted to achieve was, if the user defines `!file` tag using `resolve_tag` mechanism, 

root.yml
```
stash: &foo FOO  
included: !file include.yml
```
include.yml
```
*foo
```

Currently there's no way to do this because `yoml_parse_document` forces us to resolve all aliases and merges within the document itself. By adding `resolve_alias` and `resolve_merge` options to control the timing of those happen, we can adopt the approach that
1. Just resolve all `!file` tags first
2. Then resolve all unresolved aliases (and merges)

One consideration is that adding `resolve_*` options can break the behavior without fixing the caller side. Would it be better to make them negative options like `no_resolve_alias`?

This PR also modifies `yoml__merge` to avoid `reallocate` which is dangerous in the first place, because yoml parser passes a yoml node via `resolve_tag.cb`. If we allow the user to keep the reference to it by doing`++node->_refcnt` (e.g. cache the node), realloc that node in yoml__merge could make it a dangling pointer.
