### PR TITLE
Mapping parsing leak in the error case

### DIFF
--- a/yoml-parser.h
+++ b/yoml-parser.h
@@ -120,6 +120,7 @@ static inline yoml_t *yoml__parse_mapping(yaml_parser_t *parser, yaml_event_t *e
             }
         }
         if ((value = yoml__parse_node(parser, NULL, parse_args)) == NULL) {
+            yoml_free(key, parse_args->mem_set);
             yoml_free(map, parse_args->mem_set);
             map = NULL;
             break;


### PR DESCRIPTION
When failing to parse the value of a maping, we will return before freeing the allocated `key`.