### PR TITLE
fix memory leak during merge

### DIFF
--- a/yoml-parser.h
+++ b/yoml-parser.h
@@ -288,7 +288,6 @@ static inline int yoml__resolve_merge(yoml_t **target, yaml_parser_t *parser, yo
     return 0;
 }
 
-
 static inline int yoml__resolve_alias(yoml_t **target, yoml_t *doc, yaml_parser_t *parser, yoml_parse_args_t *parse_args)
 {
     size_t i;
@@ -351,24 +350,24 @@ static inline int yoml__resolve_tag(yoml_t **target, yaml_parser_t *parser, yoml
     }
 
     switch ((*target)->type) {
-        case YOML_TYPE_SCALAR:
-            break;
-        case YOML_TYPE_SEQUENCE:
-            for (i = 0; i != (*target)->data.sequence.size; ++i) {
-                if (yoml__resolve_tag((*target)->data.sequence.elements + i, parser, parse_args) != 0)
-                    return -1;
-            }
-            break;
-        case YOML_TYPE_MAPPING:
-            for (i = 0; i != (*target)->data.mapping.size; ++i) {
-                if (yoml__resolve_tag(&(*target)->data.mapping.elements[i].key, parser, parse_args) != 0)
-                    return -1;
-                if (yoml__resolve_tag(&(*target)->data.mapping.elements[i].value, parser, parse_args) != 0)
-                    return -1;
-            }
-            break;
-        case YOML__TYPE_UNRESOLVED_ALIAS:
-            break;
+    case YOML_TYPE_SCALAR:
+        break;
+    case YOML_TYPE_SEQUENCE:
+        for (i = 0; i != (*target)->data.sequence.size; ++i) {
+            if (yoml__resolve_tag((*target)->data.sequence.elements + i, parser, parse_args) != 0)
+                return -1;
+        }
+        break;
+    case YOML_TYPE_MAPPING:
+        for (i = 0; i != (*target)->data.mapping.size; ++i) {
+            if (yoml__resolve_tag(&(*target)->data.mapping.elements[i].key, parser, parse_args) != 0)
+                return -1;
+            if (yoml__resolve_tag(&(*target)->data.mapping.elements[i].value, parser, parse_args) != 0)
+                return -1;
+        }
+        break;
+    case YOML__TYPE_UNRESOLVED_ALIAS:
+        break;
     }
 
     return 0;

--- a/yoml-parser.h
+++ b/yoml-parser.h
@@ -213,13 +213,15 @@ static inline int yoml__merge(yoml_t **dest, size_t offset, size_t delete_count,
            ((*dest)->data.mapping.size - offset - delete_count) * sizeof(new_node->data.mapping.elements[0]));
     new_node->data.mapping.size += (*dest)->data.mapping.size - offset - delete_count;
 
-    /* increment the reference counters of the elements being added to the newly created node */
+    /* increment the reference counters of the elements being added to the newly
+     * created node */
     for (size_t i = 0; i != new_node->data.mapping.size; ++i) {
         ++new_node->data.mapping.elements[i].key->_refcnt;
         ++new_node->data.mapping.elements[i].value->_refcnt;
     }
 
     /* replace `*dest` with `new_node` */
+    yoml_free(*dest, parse_args->mem_set);
     *dest = new_node;
 
     return 0;

--- a/yoml.h
+++ b/yoml.h
@@ -26,6 +26,7 @@
 extern "C" {
 #endif
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -71,6 +72,7 @@ static inline void yoml_free(yoml_t *node, void *(*mem_set)(void *, int, size_t)
     if (node == NULL)
         return;
 
+    assert(node->_refcnt > 0);
     if (--node->_refcnt == 0) {
         free(node->filename);
         free(node->anchor);


### PR DESCRIPTION
#9 modified `yoml__merge` so that the modified node is created as a different object, rather than `realloc`-ing the original. However, it failed to decrement the reference counter of the original object even though the reference from the parent object is replaced by the newly created object.

This PR addresses this leak as well as duplicating the necessary fields, so that the new and the original object can be freed safely.